### PR TITLE
Add GitHub CI (depends of #8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt update && sudo apt install libevent-dev
+    - name: build
+      run: |
+           ./bootstrap
+           ./configure
+           make
+    - name: install_run
+      run: |
+           sudo make install
+           dnsproxy -V
+           dnsproxy -h


### PR DESCRIPTION
This PR will provide a basic CI test to build, install and run dnsproxy superficially in a Linux environment.

WARNING: this PR depends of #8 